### PR TITLE
Added antlr4 tool 'package' option and antlr4 version option

### DIFF
--- a/src/main/groovy/me/champeau/gradle/Antlr4Plugin.groovy
+++ b/src/main/groovy/me/champeau/gradle/Antlr4Plugin.groovy
@@ -18,16 +18,6 @@ package me.champeau.gradle
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-/**
- * This plugin is responsible for making sure that the Javadocs you generate using Gradle are not
- * vulnerable to frame injection, as described in http://www.kb.cert.org/vuls/id/225657
- *
- * Applying this plugin will guarantee that all generated javadoc is fixed, as well as groovydoc,
- * independently of the JDK being used to compile the project.
- *
- * @author Julien Ponge
- * @author Cedric Champeau
- */
 class Antlr4Plugin implements Plugin<Project> {
     void apply(Project project) {
         project.configurations {

--- a/src/main/groovy/me/champeau/gradle/Antlr4Plugin.groovy
+++ b/src/main/groovy/me/champeau/gradle/Antlr4Plugin.groovy
@@ -26,8 +26,12 @@ class Antlr4Plugin implements Plugin<Project> {
 
         project.extensions.create('antlr4Options', Antlr4PluginExtension)
 
-        project.dependencies {
-            antlr4 group: 'org.antlr', name: 'antlr4', version: project.antlr4Options.antlr4Version
+        project.with {
+            afterEvaluate {
+                dependencies {
+                    antlr4 group: 'org.antlr', name: 'antlr4', version: project.antlr4Options.antlr4Version
+                }
+            }
         }
 
         project.task('antlr4', type:Antlr4Task)

--- a/src/main/groovy/me/champeau/gradle/Antlr4Plugin.groovy
+++ b/src/main/groovy/me/champeau/gradle/Antlr4Plugin.groovy
@@ -23,10 +23,17 @@ class Antlr4Plugin implements Plugin<Project> {
         project.configurations {
             antlr4
         }
+
+        project.extensions.create('antlr4Options', Antlr4PluginExtension)
+
         project.dependencies {
-            antlr4 'org.antlr:antlr4:4.2.2'
+            antlr4 group: 'org.antlr', name: 'antlr4', version: project.antlr4Options.antlr4Version
         }
 
         project.task('antlr4', type:Antlr4Task)
     }
+}
+
+class Antlr4PluginExtension {
+    def String antlr4Version = '4.2.2'
 }

--- a/src/main/groovy/me/champeau/gradle/Antlr4Task.groovy
+++ b/src/main/groovy/me/champeau/gradle/Antlr4Task.groovy
@@ -64,7 +64,7 @@ class Antlr4Task extends JavaExec {
         args << (listener ? '-listener' : '-no-listener')
         args << (visitor ? '-visitor' : '-no-visitor')
         if (_package) {
-            args << '-p'
+            args << '-package'
             args << _package
         }
         if (extraArgs) {

--- a/src/main/groovy/me/champeau/gradle/Antlr4Task.groovy
+++ b/src/main/groovy/me/champeau/gradle/Antlr4Task.groovy
@@ -41,10 +41,14 @@ class Antlr4Task extends JavaExec {
 
     @Input
     @Optional
+    String _package
+
+    @Input
+    @Optional
     List extraArgs
 
     Antlr4Task() {
-    	main = 'org.antlr.v4.Tool'
+    	setMain('org.antlr.v4.Tool')
         setClasspath(project.configurations.antlr4)
     }
 
@@ -59,6 +63,10 @@ class Antlr4Task extends JavaExec {
         def args = ['-o', output]
         args << (listener ? '-listener' : '-no-listener')
         args << (visitor ? '-visitor' : '-no-visitor')
+        if (_package) {
+            args << '-p'
+            args << _package
+        }
         if (extraArgs) {
             args.addAll(extraArgs)
         }


### PR DESCRIPTION
I added support for the 'package' option to the antlr4 tool and for changing the version of antlr4 which the plugin depends on (so that you can use the latest version in a project using this plugin without updating the plugin).

I also removed an irrelevant documentation comment which seems to have been copied from another plugin.